### PR TITLE
Modify indentation for proper sub-list rendering

### DIFF
--- a/JS101/javascript-dev-tools.md
+++ b/JS101/javascript-dev-tools.md
@@ -6,30 +6,29 @@ Knowing how to use the Developers Tools inside your browser is an important skil
 There are three ways to open the Developer Tools menu:
 
 1. From the Browser Menu:
-  - Chrome: Select the `Chrome Menu` > `More Tools` > `Developer Tools`
-
-  - Firefox: Select the Firefox `Menu` > `Web Developer`> `Toggle Tools`
+    - Chrome: Select the `Chrome Menu` > `More Tools` > `Developer Tools`
+    - Firefox: Select the Firefox `Menu` > `Web Developer`> `Toggle Tools`  
 2. Right click anywhere on a webpage and select `Inspect`
 3. Use the keyboard shortcut `CTRL + Shift + I` (`option + command + I` on Mac)
 
 ### Assignment
 
 <div class="lesson-content__panel" markdown="1">
-1. Head to the [Chrome DevTools Documentation](https://developers.google.com/web/tools/chrome-devtools/) by Google. Read these subsections, since this is what you'll be using the Developer Tools for 95% of the time.
-  * Open DevTools
-  * Device Mode
-    1. Device Mode
-    2. Test Responsive and Device-specific Viewports
-  * Elements panel
-    1. Get Started With Viewing and Changing CSS
-    2. Inspect and Tweak Your Pages
-    3. Edit Styles
-    4. Edit the DOM
-  * Using the Console
-  * Sources panel
-    1. Get Started With Debugging JavaScript
-    2. Pause Your Code With Breakpoints
-2. Finally, watch [this video](https://www.youtube.com/watch?v=JzZFccCEgGA) by The Net Ninja for more detail on using the JavaScript Console.
+1. Head to the [Chrome DevTools Documentation](https://developers.google.com/web/tools/chrome-devtools/) by Google. Read following subsections, since this is what you'll be using the Developer Tools for 95% of the time:
+    - Open DevTools
+    - Device Mode
+        1. Device Mode
+        2. Test Responsive and Device-specific Viewports
+    - Elements panel
+        1. Get Started With Viewing and Changing CSS
+        2. Inspect and Tweak Your Pages
+        3. Edit Styles
+        4. Edit the DOM
+    - Using the Console
+    - Sources panel
+        1. Get Started With Debugging JavaScript
+        2. Pause Your Code With Breakpoints
+ 2. Then, watch [this video](https://www.youtube.com/watch?v=JzZFccCEgGA) by The Net Ninja for more detail on using the JavaScript Console.
 
 These resoures should give you a pretty good starting point for understanding how to use DevTools.  The more you use and understand the abilities of Dev Tools the easier your life as a developer becomes.
 </div>


### PR DESCRIPTION
4 spaces are used to indent sub-lists, so that they appear like so in rendered .md file/webpage.

" * " were replaced with " - " as prefix character for un-ordered lists.